### PR TITLE
Improve Friday the 13th finder: validate input and centralize date handling

### DIFF
--- a/nf13.rb
+++ b/nf13.rb
@@ -3,6 +3,7 @@
 # Simple ruby script which returns next Friday the 13th dates
 #
 
+require 'date'
 require 'optparse'
 
 class Friday13thFinder
@@ -27,23 +28,17 @@ class Friday13thFinder
       end
     end.parse!
   rescue OptionParser::InvalidOption, OptionParser::MissingArgument => e
-    puts "Error: #{e.message}"
-    puts "Use -h for help"
-    exit 1
+    abort_with_error(e.message)
   end
 
   def find_friday_13ths
-    current_year = Time.now.year
-    max_year = current_year + @options[:years_ahead]
+    current_year = Date.today.year
+    max_year = current_year + years_ahead
 
     (current_year..max_year).flat_map do |year|
       (1..12).map do |month|
-        begin
-          date = Date.new(year, month, 13)
-          date if date.friday?
-        rescue ArgumentError
-          nil # Skip invalid dates (like Feb 29 in non-leap years)
-        end
+        date = Date.new(year, month, 13)
+        date if date.friday?
       end.compact
     end
   end
@@ -54,11 +49,11 @@ class Friday13thFinder
 
   def display_dates(dates)
     if dates.empty?
-      puts "No Friday the 13th dates found in the next #{@options[:years_ahead]} years."
+      puts "No Friday the 13th dates found in the next #{years_ahead} years."
       return
     end
 
-    puts "Friday the 13th dates for the next #{@options[:years_ahead]} years:"
+    puts "Friday the 13th dates for the next #{years_ahead} years:"
     puts "-" * 50
     
     formatted_dates = format_dates(dates)
@@ -70,9 +65,23 @@ class Friday13thFinder
   end
 
   def run
-    require 'date'
     dates = find_friday_13ths
     display_dates(dates)
+  end
+
+  private
+
+  def years_ahead
+    years = @options[:years_ahead]
+    return years if years.is_a?(Integer) && years >= 0
+
+    abort_with_error("Years ahead must be a non-negative integer.")
+  end
+
+  def abort_with_error(message)
+    warn "Error: #{message}"
+    warn "Use -h for help"
+    exit 1
   end
 end
 


### PR DESCRIPTION
### Motivation
- Ensure the script consistently uses `Date` APIs and avoids mixing `Time` and `Date` for year calculations.
- Provide clearer and centralized validation for the `years_ahead` option so invalid input fails with a helpful message.
- Simplify date generation by removing unnecessary error handling for invalid month/day combinations.

### Description
- Move `require 'date'` to the top of the file and use `Date.today.year` instead of `Time.now.year` for consistency.
- Add a private `years_ahead` helper that validates `@options[:years_ahead]` is a non-negative integer and is reused throughout the code.
- Replace inline `OptionParser` rescue handling with a shared `abort_with_error` method that prints an error and usage hint and exits with a non-zero code.
- Simplify the per-month date generation by creating `Date.new(year, month, 13)` directly and relying on valid inputs, and update output messages to use the validated `years_ahead` helper.

### Testing
- No automated tests were run.

------
